### PR TITLE
Implement `ASRA::Named#strategy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   check_format:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal
+      image: crystallang/crystal:latest-alpine
     steps:
       - uses: actions/checkout@v2
       - name: Format
@@ -19,7 +19,7 @@ jobs:
   coding_standards:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal
+      image: crystallang/crystal:latest-alpine
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
@@ -29,7 +29,7 @@ jobs:
   test_latest:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal
+      image: crystallang/crystal:latest-alpine
     steps:
       - uses: actions/checkout@v2
       - name: Specs
@@ -37,7 +37,7 @@ jobs:
   test_nightly:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal:nightly
+      image: crystallang/crystal:nightly-alpine
     steps:
       - uses: actions/checkout@v2
       - name: Specs

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: athena-serializer
 
-version: 0.1.0
+version: 0.1.1
 
 crystal: 0.35.0
 

--- a/spec/athena-serializer_spec.cr
+++ b/spec/athena-serializer_spec.cr
@@ -138,6 +138,68 @@ describe ASR::Serializable do
           p.class.should eq SerializedName
         end
       end
+
+      describe :strategy do
+        it :camelcase do
+          properties = SerializedNameCamelcaseStrategy.new.serialization_properties
+          properties.size.should eq 3
+
+          p = properties[0]
+
+          p.name.should eq "my_home_address"
+          p.external_name.should eq "myAdd_ress"
+
+          p = properties[1]
+
+          p.name.should eq "two_wOrds"
+          p.external_name.should eq "twoWOrds"
+
+          p = properties[2]
+
+          p.name.should eq "myZipCode"
+          p.external_name.should eq "myZipCode"
+        end
+
+        it :underscore do
+          properties = SerializedNameUnderscoreStrategy.new.serialization_properties
+          properties.size.should eq 3
+
+          p = properties[0]
+
+          p.name.should eq "my_home_address"
+          p.external_name.should eq "myAdd_ress"
+
+          p = properties[1]
+
+          p.name.should eq "two_wOrds"
+          p.external_name.should eq "two_w_ords"
+
+          p = properties[2]
+
+          p.name.should eq "myZipCode"
+          p.external_name.should eq "my_zip_code"
+        end
+
+        it :identical do
+          properties = SerializedNameIdenticalStrategy.new.serialization_properties
+          properties.size.should eq 3
+
+          p = properties[0]
+
+          p.name.should eq "my_home_address"
+          p.external_name.should eq "myAdd_ress"
+
+          p = properties[1]
+
+          p.name.should eq "two_wOrds"
+          p.external_name.should eq "two_wOrds"
+
+          p = properties[2]
+
+          p.name.should eq "myZipCode"
+          p.external_name.should eq "myZipCode"
+        end
+      end
     end
 
     describe ASRA::SkipWhenEmpty do

--- a/spec/models/name.cr
+++ b/spec/models/name.cr
@@ -23,6 +23,7 @@ class SerializedNameCamelcaseStrategy
   @[ASRA::Name(serialize: "myAdd_ress")]
   property my_home_address : String = "123 Fake Street"
 
+  # ameba:disable Style/VariableNames
   property two_wOrds : String = "two words"
 
   # ameba:disable Style/VariableNames
@@ -39,6 +40,7 @@ class SerializedNameUnderscoreStrategy
   @[ASRA::Name(serialize: "myAdd_ress")]
   property my_home_address : String = "123 Fake Street"
 
+  # ameba:disable Style/VariableNames
   property two_wOrds : String = "two words"
 
   # ameba:disable Style/VariableNames
@@ -55,6 +57,7 @@ class SerializedNameIdenticalStrategy
   @[ASRA::Name(serialize: "myAdd_ress")]
   property my_home_address : String = "123 Fake Street"
 
+  # ameba:disable Style/VariableNames
   property two_wOrds : String = "two words"
 
   # ameba:disable Style/VariableNames

--- a/spec/models/name.cr
+++ b/spec/models/name.cr
@@ -13,6 +13,54 @@ class SerializedName
   property myZipCode : Int32 = 90210
 end
 
+@[ASRA::Name(strategy: :camelcase)]
+class SerializedNameCamelcaseStrategy
+  include ASR::Serializable
+
+  def initialize; end
+
+  # Is overridable
+  @[ASRA::Name(serialize: "myAdd_ress")]
+  property my_home_address : String = "123 Fake Street"
+
+  property two_wOrds : String = "two words"
+
+  # ameba:disable Style/VariableNames
+  property myZipCode : Int32 = 90210
+end
+
+@[ASRA::Name(strategy: :underscore)]
+class SerializedNameUnderscoreStrategy
+  include ASR::Serializable
+
+  def initialize; end
+
+  # Is overridable
+  @[ASRA::Name(serialize: "myAdd_ress")]
+  property my_home_address : String = "123 Fake Street"
+
+  property two_wOrds : String = "two words"
+
+  # ameba:disable Style/VariableNames
+  property myZipCode : Int32 = 90210
+end
+
+@[ASRA::Name(strategy: :identical)]
+class SerializedNameIdenticalStrategy
+  include ASR::Serializable
+
+  def initialize; end
+
+  # Is overridable
+  @[ASRA::Name(serialize: "myAdd_ress")]
+  property my_home_address : String = "123 Fake Street"
+
+  property two_wOrds : String = "two words"
+
+  # ameba:disable Style/VariableNames
+  property myZipCode : Int32 = 90210
+end
+
 class DeserializedName
   include ASR::Serializable
 

--- a/spec/visitors/yaml_serialization_visitor_spec.cr
+++ b/spec/visitors/yaml_serialization_visitor_spec.cr
@@ -40,7 +40,11 @@ describe ASR::Visitors::YAMLSerializationVisitor do
       end
 
       it Nil do
-        assert_serialized_output(ASR::Visitors::YAMLSerializationVisitor, build_expected_yaml_string "--- \n") do |visitor|
+        str = "---"
+        str += " " if YAML.libyaml_version < SemanticVersion.new(0, 2, 5)
+        str += '\n'
+
+        assert_serialized_output(ASR::Visitors::YAMLSerializationVisitor, build_expected_yaml_string str) do |visitor|
           visitor.visit nil
         end
       end

--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -328,6 +328,7 @@ module Athena::Serializer::Annotations
   # * `serialize : String` - The key to use for this property during serialization.
   # * `deserialize : String` - The key to use for this property during deserialization.
   # * `aliases : Array(String)` - A set of keys to use for this property during deserialization; is equivalent to multiple `deserialize` keys.
+  # * `strategy : Symbol` - Defines the default serialization naming strategy for this type.  Can be overridden using the `serialize` field.
   #
   # ## Example
   #
@@ -354,6 +355,33 @@ module Athena::Serializer::Annotations
   # obj.my_home_address # => "555 Mason Ave"
   # obj.both_names      # => "deserialized from diff key"
   # obj.some_value      # => "some_other_val"
+  # ```
+  #
+  # ### Naming Strategies
+  #
+  # By default the keys in the serialized data match exactly to the name of the property.
+  # Naming strategies allow changing this behavior for all properties within the type.
+  # The serialized name can still be overridden on a per-property basis via
+  # using the `ASRA::Name` annotation with the `serialize` field.
+  #
+  # The available naming strategies include:
+  # * `:camelcase`
+  # * `:underscore`
+  # * `:identical`
+  #
+  # ```
+  # @[ASRA::Name(strategy: :camelcase)]
+  # class User
+  #   include ASR::Serializable
+  #
+  #   def initialize; end
+  #
+  #   property id : Int32 = 1
+  #   property first_name : String = "Jon"
+  #   property last_name : String = "Snow"
+  # end
+  #
+  # ASR.serializer.serialize User.new, :json # => {"id":1,"firstName":"Jon","lastName":"Snow"}
   # ```
   annotation Name; end
 

--- a/src/athena-serializer.cr
+++ b/src/athena-serializer.cr
@@ -168,7 +168,7 @@ module Athena::Serializer
                                    serialized_name
                                  elsif (name_ann = @type.annotation(ASRA::Name)) && (strategy = name_ann[:strategy])
                                    if strategy == :camelcase
-                                     ivar_name.camelcase(lower: true)
+                                     ivar_name.camelcase lower: true
                                    elsif strategy == :underscore
                                      ivar_name.underscore
                                    elsif strategy == :identical


### PR DESCRIPTION
* Can be applied to a type to determine how each ivar's name should appear in the serialized output
  * Options include:
    * `:camelcase` - Camelcases ivar names. `first_name` becomes `firstName`
    * `:underscore` - Underscores ivar names
    * `:identical` - Default behavior, name is identical to the ivar's name; essentially the same `:underscore` due to naming conventions
